### PR TITLE
Fix for Closure being namespaced to \Roots\Closure

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -57,7 +57,7 @@ function env($key, $default = null)
  */
 function value($value)
 {
-    return $value instanceof Closure ? $value() : $value;
+    return $value instanceof \Closure ? $value() : $value;
 }
 
 /**


### PR DESCRIPTION
The `value` method is namespaced to `Roots\value`. The method is using the `Closure` class from the global namespace.

However, as it's within the Roots namespace, it is incorrectly using `\Roots\Closure`. 

This PR adds a backtick to the `Closure` class to ensure it is `Closure` from the global namespace.

![image](https://user-images.githubusercontent.com/2754728/108187656-9a747d00-7106-11eb-8077-e47d758e696a.png)

It seems the function came from https://github.com/laravel/framework/blob/v5.6.25/src/Illuminate/Support/helpers.php#L1143-L1152 - this file is not namespaced.